### PR TITLE
Add task reminders and notification infrastructure

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -16,6 +16,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   category TEXT NOT NULL,
   category_color TEXT NOT NULL,
   due_date DATE,
+  reminder_time TIMESTAMP WITH TIME ZONE,
+  reminder_sent BOOLEAN DEFAULT FALSE,
   repeat_interval TEXT CHECK (repeat_interval IN ('none','daily','weekly','monthly','yearly')) DEFAULT 'none',
   "order" INTEGER NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -34,11 +34,22 @@ CREATE TABLE IF NOT EXISTS categories (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Store web push subscriptions for each user
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint TEXT NOT NULL,
+  p256dh TEXT NOT NULL,
+  auth TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_tasks_user_id ON tasks(user_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_order ON tasks("order");
 CREATE INDEX IF NOT EXISTS idx_tasks_category ON tasks(category);
 CREATE INDEX IF NOT EXISTS idx_categories_user_id ON categories(user_id);
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user_id ON push_subscriptions(user_id);
 
 -- Create function to update updated_at timestamp
 CREATE OR REPLACE FUNCTION update_updated_at_column()
@@ -67,6 +78,7 @@ ON CONFLICT (name) DO NOTHING;
 -- Row Level Security (RLS) policies
 ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
 
 -- Tasks policies
 CREATE POLICY "Users can view their own tasks" ON tasks
@@ -93,3 +105,7 @@ CREATE POLICY "Users can update their own categories" ON categories
 
 CREATE POLICY "Users can delete their own categories" ON categories
   FOR DELETE USING (auth.uid() = user_id);
+
+-- Push subscription policies
+CREATE POLICY "Users manage their own subscriptions" ON push_subscriptions
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);

--- a/public/notification-sw.js
+++ b/public/notification-sw.js
@@ -1,0 +1,14 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Task Reminder';
+  const options = {
+    body: data.body || '',
+    icon: '/icon.png'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(clients.openWindow('/'));
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect } from "react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -22,6 +25,11 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/notification-sw.js").catch(console.error);
+    }
+  }, []);
   return (
     <html lang="en">
       <body

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,7 @@
-"use client";
-
-import { useEffect } from "react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,17 +23,11 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  useEffect(() => {
-    if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.register("/notification-sw.js").catch(console.error);
-    }
-  }, []);
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
+        <ServiceWorkerRegister />
       </body>
     </html>
   );

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,12 +1,52 @@
 "use client";
 
 import { useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = window.atob(base64);
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+}
 
 export default function ServiceWorkerRegister() {
   useEffect(() => {
-    if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.register("/notification-sw.js").catch(console.error);
-    }
+    const register = async () => {
+      if (!("serviceWorker" in navigator)) return;
+      try {
+        const registration = await navigator.serviceWorker.register("/notification-sw.js");
+        if (Notification.permission !== "granted") {
+          await Notification.requestPermission();
+        }
+        if (Notification.permission !== "granted") return;
+
+        const existing = await registration.pushManager.getSubscription();
+        const subscription = existing ||
+          (await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(
+              process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY as string
+            ),
+          }));
+
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user) {
+          const sub = subscription.toJSON();
+          await supabase.from("push_subscriptions").upsert({
+            user_id: user.id,
+            endpoint: sub.endpoint,
+            p256dh: sub.keys?.p256dh,
+            auth: sub.keys?.auth,
+          });
+        }
+      } catch (err) {
+        console.error("Service worker registration failed", err);
+      }
+    };
+    register();
   }, []);
   return null;
 }

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/notification-sw.js").catch(console.error);
+    }
+  }, []);
+  return null;
+}
+

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -25,6 +25,8 @@ export default function TaskForm({ categories, onSubmit, onClose }: TaskFormProp
     category: categories[0]?.name || '',
     category_color: categories[0]?.color || '#3B82F6',
     due_date: '',
+    reminder_time: '',
+    reminder_sent: false,
     repeat_interval: 'none',
     pinned: false
   })
@@ -39,6 +41,8 @@ export default function TaskForm({ categories, onSubmit, onClose }: TaskFormProp
         category: selectedCategory?.name || 'General',
         category_color: selectedCategory?.color || '#6B7280',
         due_date: formData.due_date || null,
+        reminder_time: formData.reminder_time ? new Date(formData.reminder_time).toISOString() : null,
+        reminder_sent: false,
         completed: false,
         archived: false,
         order: 0
@@ -118,6 +122,18 @@ export default function TaskForm({ categories, onSubmit, onClose }: TaskFormProp
           type="date"
           value={formData.due_date}
           onChange={(e) => setFormData(prev => ({ ...prev, due_date: e.target.value }))}
+          className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-cyan-200 mb-2">
+          Reminder Time
+        </label>
+        <input
+          type="datetime-local"
+          value={formData.reminder_time}
+          onChange={(e) => setFormData(prev => ({ ...prev, reminder_time: e.target.value }))}
           className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
         />
       </div>

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -6,7 +6,7 @@ import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, us
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { CheckCircle2, Circle, Trash2, Star, Calendar, GripVertical, Edit2, Check, X, Archive, Pin, Repeat } from 'lucide-react'
+import { CheckCircle2, Circle, Trash2, Star, Calendar, GripVertical, Edit2, Check, X, Archive, Pin, Repeat, Bell, BellOff } from 'lucide-react'
 import { Task, Category, PRIORITY_COLORS, PRIORITY_LABELS, REPEAT_LABELS } from '@/types'
 
 interface TaskListProps {
@@ -38,6 +38,7 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
     category: task.category,
     category_color: task.category_color,
     due_date: task.due_date ? task.due_date.split('T')[0] : '',
+    reminder_time: task.reminder_time ? task.reminder_time.slice(0, 16) : '',
     repeat_interval: task.repeat_interval
   })
 
@@ -49,6 +50,7 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
       category: task.category,
       category_color: task.category_color,
       due_date: task.due_date ? task.due_date.split('T')[0] : '',
+      reminder_time: task.reminder_time ? task.reminder_time.slice(0, 16) : '',
       repeat_interval: task.repeat_interval
     })
   }, [task])
@@ -71,6 +73,8 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
       category: editData.category,
       category_color: editData.category_color,
       due_date: editData.due_date || null,
+      reminder_time: editData.reminder_time ? new Date(editData.reminder_time).toISOString() : null,
+      reminder_sent: false,
       repeat_interval: editData.repeat_interval
     })
     setIsEditing(false)
@@ -86,6 +90,7 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
       category: task.category,
       category_color: task.category_color,
       due_date: task.due_date ? task.due_date.split('T')[0] : '',
+      reminder_time: task.reminder_time ? task.reminder_time.slice(0, 16) : '',
       repeat_interval: task.repeat_interval
     })
   }
@@ -196,6 +201,12 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
                 value={editData.due_date}
                 onChange={(e) => setEditData(prev => ({ ...prev, due_date: e.target.value }))}
               />
+              <input
+                type="datetime-local"
+                className="w-full mb-2 px-2 py-1 bg-white/10 border border-white/20 rounded text-white focus:outline-none"
+                value={editData.reminder_time}
+                onChange={(e) => setEditData(prev => ({ ...prev, reminder_time: e.target.value }))}
+              />
               <div className="flex items-center gap-2">
                 <select
                   value={editData.priority}
@@ -286,6 +297,22 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
                   <Calendar className="w-3 h-3 mr-1" />
                   {new Date((task.due_date || task.created_at)).toLocaleDateString()}
                 </span>
+                {task.reminder_time && (
+                  <span
+                    className={`text-xs flex items-center ${
+                      task.reminder_sent ? 'text-green-300' : 'text-cyan-300'
+                    }`}
+                  >
+                    {task.reminder_sent ? (
+                      <Check className="w-3 h-3 mr-1" />
+                    ) : (
+                      <Bell className="w-3 h-3 mr-1" />
+                    )}
+                    {task.reminder_sent
+                      ? 'Reminder sent'
+                      : new Date(task.reminder_time).toLocaleString()}
+                  </span>
+                )}
               </div>
             </>
           )}
@@ -323,6 +350,23 @@ function SortableTaskItem({ task, categories, onToggle, onDelete, onArchive, onE
             <Edit2 className="w-5 h-5" />
           </motion.button>
         )}
+        <motion.button
+          onClick={(e) => {
+            e.stopPropagation()
+            if (task.reminder_time) {
+              onEdit(task.id, { reminder_time: null, reminder_sent: false })
+            } else {
+              setIsEditing(true)
+            }
+          }}
+          className={`flex-shrink-0 hover:scale-110 transition-all duration-200 hover:bg-white/10 p-2 rounded-lg ${
+            task.reminder_time ? 'text-green-400 hover:text-green-300' : 'text-gray-400 hover:text-gray-300'
+          }`}
+          whileHover={{ scale: 1.1, rotate: 5 }}
+          whileTap={{ scale: 0.9, rotate: -5 }}
+        >
+          {task.reminder_time ? <Bell className="w-5 h-5" /> : <BellOff className="w-5 h-5" />}
+        </motion.button>
 
         <motion.button
           onClick={(e) => {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -14,9 +14,15 @@ export type Database = {
           title: string
           description: string | null
           completed: boolean
+          archived: boolean
+          pinned: boolean
           priority: 'low' | 'medium' | 'high'
           category: string
           category_color: string
+          due_date: string | null
+          reminder_time: string | null
+          reminder_sent: boolean
+          repeat_interval: 'none' | 'daily' | 'weekly' | 'monthly' | 'yearly'
           order: number
           created_at: string
           updated_at: string
@@ -27,9 +33,15 @@ export type Database = {
           title: string
           description?: string | null
           completed?: boolean
+          archived?: boolean
+          pinned?: boolean
           priority?: 'low' | 'medium' | 'high'
           category: string
           category_color: string
+          due_date?: string | null
+          reminder_time?: string | null
+          reminder_sent?: boolean
+          repeat_interval?: 'none' | 'daily' | 'weekly' | 'monthly' | 'yearly'
           order: number
           created_at?: string
           updated_at?: string
@@ -40,9 +52,15 @@ export type Database = {
           title?: string
           description?: string | null
           completed?: boolean
+          archived?: boolean
+          pinned?: boolean
           priority?: 'low' | 'medium' | 'high'
           category?: string
           category_color?: string
+          due_date?: string | null
+          reminder_time?: string | null
+          reminder_sent?: boolean
+          repeat_interval?: 'none' | 'daily' | 'weekly' | 'monthly' | 'yearly'
           order?: number
           created_at?: string
           updated_at?: string
@@ -69,6 +87,32 @@ export type Database = {
           name?: string
           color?: string
           user_id?: string
+          created_at?: string
+        }
+      }
+      push_subscriptions: {
+        Row: {
+          id: string
+          user_id: string
+          endpoint: string
+          p256dh: string
+          auth: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          endpoint: string
+          p256dh: string
+          auth: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          endpoint?: string
+          p256dh?: string
+          auth?: string
           created_at?: string
         }
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,8 @@ export interface Task {
   category: string
   category_color: string
   due_date: string | null
+  reminder_time: string | null
+  reminder_sent: boolean
   repeat_interval: RepeatInterval
   order: number
   created_at: string
@@ -31,6 +33,8 @@ export interface TaskFormData {
   category: string
   category_color: string
   due_date: string
+  reminder_time: string
+  reminder_sent: boolean
   repeat_interval: RepeatInterval
   pinned: boolean
 }

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -38,26 +38,28 @@ serve(async () => {
         .eq("user_id", task.user_id);
 
       if (subs) {
-        for (const sub of subs) {
-          try {
-            await webpush.sendNotification(
-              {
-                endpoint: sub.endpoint,
-                keys: { p256dh: sub.p256dh, auth: sub.auth },
-              },
-              JSON.stringify({ title: "Task Reminder", body: task.title })
-            );
-          } catch (err) {
-            // Remove invalid subscriptions
-            if ((err as { statusCode?: number }).statusCode === 410) {
-              await supabase
-                .from("push_subscriptions")
-                .delete()
-                .eq("endpoint", sub.endpoint);
+        await Promise.all(
+          subs.map(async (sub) => {
+            try {
+              await webpush.sendNotification(
+                {
+                  endpoint: sub.endpoint,
+                  keys: { p256dh: sub.p256dh, auth: sub.auth },
+                },
+                JSON.stringify({ title: "Task Reminder", body: task.title })
+              );
+            } catch (err) {
+              const status = (err as { statusCode?: number }).statusCode;
+              if (status === 410 || status === 404) {
+                await supabase
+                  .from("push_subscriptions")
+                  .delete()
+                  .eq("endpoint", sub.endpoint);
+              }
+              console.error(err);
             }
-            console.error(err);
-          }
-        }
+          })
+        );
       }
     }
 

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -1,0 +1,42 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type ReminderTask = {
+  id: string;
+  user_id: string;
+  title: string;
+  reminder_time: string;
+};
+
+serve(async () => {
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  const now = new Date().toISOString();
+  const { data: tasks } = await supabase
+    .from<ReminderTask>("tasks")
+    .select("id, user_id, title, reminder_time")
+    .lte("reminder_time", now)
+    .eq("reminder_sent", false);
+
+  if (tasks) {
+    for (const task of tasks) {
+      // TODO: send web push notification to the user
+      console.log(`Send reminder for task ${task.id} to user ${task.user_id}`);
+    }
+    await supabase
+      .from("tasks")
+      .update({ reminder_sent: true })
+      .in(
+        "id",
+        tasks.map((t) => t.id)
+      );
+  }
+
+  return new Response(
+    JSON.stringify({ sent: tasks?.length ?? 0 }),
+    { headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -2,7 +2,8 @@
 // @ts-nocheck
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import webpush from "https://esm.sh/web-push@3.6.9";
+// Use npm specifier for Node compatibility in Supabase Edge runtime
+import webpush from "npm:web-push@3.6.9";
 
 type ReminderTask = {
   id: string;
@@ -31,13 +32,17 @@ serve(async () => {
       Deno.env.get("WEB_PUSH_PRIVATE_KEY")!
     );
 
+    const sentTaskIds: string[] = [];
+
     for (const task of tasks) {
       const { data: subs } = await supabase
         .from("push_subscriptions")
         .select("endpoint, p256dh, auth")
         .eq("user_id", task.user_id);
 
-      if (subs) {
+      if (subs && subs.length) {
+        let delivered = false;
+
         await Promise.all(
           subs.map(async (sub) => {
             try {
@@ -48,6 +53,7 @@ serve(async () => {
                 },
                 JSON.stringify({ title: "Task Reminder", body: task.title })
               );
+              delivered = true;
             } catch (err) {
               const status = (err as { statusCode?: number }).statusCode;
               if (status === 410 || status === 404) {
@@ -60,16 +66,19 @@ serve(async () => {
             }
           })
         );
+
+        if (delivered) {
+          sentTaskIds.push(task.id);
+        }
       }
     }
 
-    await supabase
-      .from("tasks")
-      .update({ reminder_sent: true })
-      .in(
-        "id",
-        tasks.map((t) => t.id)
-      );
+    if (sentTaskIds.length) {
+      await supabase
+        .from("tasks")
+        .update({ reminder_sent: true })
+        .in("id", sentTaskIds);
+    }
   }
 
   return new Response(

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import webpush from "https://esm.sh/web-push@3.6.9";
 
 type ReminderTask = {
   id: string;
@@ -24,10 +25,42 @@ serve(async () => {
     .eq("reminder_sent", false);
 
   if (tasks) {
+    webpush.setVapidDetails(
+      Deno.env.get("WEB_PUSH_CONTACT") || "mailto:example@example.com",
+      Deno.env.get("WEB_PUSH_PUBLIC_KEY")!,
+      Deno.env.get("WEB_PUSH_PRIVATE_KEY")!
+    );
+
     for (const task of tasks) {
-      // TODO: send web push notification to the user
-      console.log(`Send reminder for task ${task.id} to user ${task.user_id}`);
+      const { data: subs } = await supabase
+        .from("push_subscriptions")
+        .select("endpoint, p256dh, auth")
+        .eq("user_id", task.user_id);
+
+      if (subs) {
+        for (const sub of subs) {
+          try {
+            await webpush.sendNotification(
+              {
+                endpoint: sub.endpoint,
+                keys: { p256dh: sub.p256dh, auth: sub.auth },
+              },
+              JSON.stringify({ title: "Task Reminder", body: task.title })
+            );
+          } catch (err) {
+            // Remove invalid subscriptions
+            if ((err as { statusCode?: number }).statusCode === 410) {
+              await supabase
+                .from("push_subscriptions")
+                .delete()
+                .eq("endpoint", sub.endpoint);
+            }
+            console.error(err);
+          }
+        }
+      }
     }
+
     await supabase
       .from("tasks")
       .update({ reminder_sent: true })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## Summary
- extend Task model with reminder fields and form inputs
- display reminder status in task list with controls to manage reminders
- register service worker and add edge function to send notifications

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b22a443980832da2da5beb15eec143